### PR TITLE
feat(goalert): add support for extraEnv and extraEnvFrom

### DIFF
--- a/charts/goalert/Chart.yaml
+++ b/charts/goalert/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: goalert
 sources:
   - https://github.com/target/goalert
-version: 0.0.5
+version: 0.0.6
 dependencies:
   - name: postgresql
     version: 15.x.x

--- a/charts/goalert/templates/deployment.yaml
+++ b/charts/goalert/templates/deployment.yaml
@@ -44,6 +44,16 @@ spec:
             - name: GOALERT_DATA_ENCRYPTION_KEY
               value: {{ .Values.goalert.environment.GOALERT_DATA_ENCRYPTION_KEY | quote }}
             {{- end }}
+            {{- if and (.Values.extraEnv) (gt (len .Values.extraEnv) 0) }}
+            {{- .Values.extraEnv | toYaml | nindent 12 }}
+            {{- end }}
+          {{- if and (.Values.extraEnvFrom) (gt (len .Values.extraEnvFrom) 0) }}
+          envFrom:
+            {{- range .Values.extraEnvFrom }}
+            - {{ .type }}:
+                name: {{ .name }}
+            {{- end }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/goalert/values.schema.json
+++ b/charts/goalert/values.schema.json
@@ -260,6 +260,16 @@
             "type": "number",
             "description": "Number of replica pods to run",
             "default": 1
+        },
+        "extraEnv": {
+            "type": "array",
+            "description": "Extra Environment Variables to set for the GoAlert Pod",
+            "default": []
+        },
+        "extraEnvFrom": {
+            "type": "array",
+            "description": "Use Secrets and ConfigMaps to set Extra Environment Variables for the GoAlert Pod",
+            "default": []
         }
     }
 }

--- a/charts/goalert/values.yaml
+++ b/charts/goalert/values.yaml
@@ -172,3 +172,11 @@ securityContext:
 ## @param replicaCount Number of replica pods to run
 ##
 replicaCount: 1
+
+## @param Extra Environment Variables to set for the GoAlert Pod
+##
+extraEnv: []
+
+## @param Use Secrets and ConfigMaps to set Extra Environment Variables for the GoAlert Pod
+##
+extraEnvFrom: []


### PR DESCRIPTION
Hello there!

I've found your Helm Chart for GoAlert quite useful.
However I missed the feature of setting configuration options to GoAlert via Environment Variables (for example `GOALERT_PUBLIC_URL` as seen [here](https://github.com/target/goalert/blob/master/docs/getting-started.md#cli-flags)) and I decided to contribute to your work and extend it a bit. I hope someone will find this change useful. 

Please let me know if there is something I should improve to get this change merged. I am quite new to contributing to Helm Chart but since I am using this Chart, I'd love to help :) 

